### PR TITLE
Installation instructions updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Publications using models, data or simulators provided with CIFF.
 
 ## How to Use CIFF
 
-1) Clone the repostory using `git clone https://github.com/clic-lab/instruction-following-framework.git`
+1) Clone the repostory using `git clone https://github.com/lil-lab/ciff.git`
 
 2) Download the data and simulators file from http://clic.nlp.cornell.edu/resources/Misra-EMNLP-2018/. Note that images for Touchdown dataset are not available publically since Google owns these images. We do however provide image features. Please see the Section 9 in the Touchdown paper for full details. Place the data and simulator files in the same ciff folder alongside the src folder. The CIFF directory should contain 4 folders: src, simulators, data and media.
      
@@ -68,7 +68,7 @@ Publications using models, data or simulators provided with CIFF.
 
 4) Run an experiment. This is essentially done by running a file as:
 
-   `python3 src/experiment_domain_name/experiment_name.py`
+   `python3 src/experiments_domain_name/experiment_name.py`
 
    where `domain_name` is the name of the domain (e.g., nav_drone for LANI, house for CHAI, streetview for touchdown, blocks for blocks) and `experiment_name` is the name of the experiment you want to run.
 


### PR DESCRIPTION
This pull request contains fixes for minor issues I encountered while trying to use this software:

1. The repository link in the instructions, `git clone https://github.com/clic-lab/instruction-following-framework.git`, no longer exists. 
2. The prefix in the command `python3 src/experiment_domain_name/experiment_name.py` was experiment but the folder uses the plural form experiments

With this pull request, the following changes are made:
1. Repo link in read me is updated to `git clone https://github.com/lil-lab/ciff.git`
2. Prefix for domain name in read me changed from `experiment` to `experiments` to match folder names